### PR TITLE
Better port finding, Python 3 fixes, and util.draw cleanup

### DIFF
--- a/axi/device.py
+++ b/axi/device.py
@@ -110,8 +110,8 @@ class Device(object):
         return self.serial.readline().strip()
 
     def command(self, *args):
-        line = ','.join(map(str, args))
-        self.serial.write(line + '\r')
+        line = ','.join(map(str, args)) + '\r'
+        self.serial.write(line.encode())
         return self.readline()
 
     # higher level functions

--- a/axi/device.py
+++ b/axi/device.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
 
 import time
+import re
 
 from math import modf
 from serial import Serial
@@ -33,11 +34,23 @@ CORNER_FACTOR = 0.005
 JOG_ACCELERATION = 16
 JOG_MAX_VELOCITY = 8
 
-VID_PID = '04D8:FD92'
+VID = 0x04D8
+PID = 0xFD92
+
+def get_vid_pid(port):
+    if hasattr(port, 'vid'):
+        return (port.vid, port.pid)
+
+    match = re.search(r'VID:PID=([0-9A-Fa-f]+):([0-9A-Fa-f]+)', port[2])
+    if match:
+        return tuple(int(m, 16) for m in match.groups())
+
+    return (None, None)
+
 
 def find_port():
     for port in comports():
-        if VID_PID in port[2]:
+        if (VID, PID) == get_vid_pid(port):
             return port[0]
     return None
 

--- a/axi/util.py
+++ b/axi/util.py
@@ -9,5 +9,8 @@ def draw(drawing, progress=True):
     # TODO: support drawing, list of paths, or single path
     d = Device()
     d.enable_motors()
-    d.run_drawing(drawing, progress)
-    d.disable_motors()
+    try:
+        d.run_drawing(drawing, progress)
+    finally:
+        d.disable_motors()
+        d.pen_up()


### PR DESCRIPTION
Hi! I've fixed a couple things in my fork that you might like.

I made the port finding use pyserial 3's `.pid`/`.vid`, and fall back to more robust string parsing for pyserial 2 that should match obscure cases like `USB VID:PID=4d8:fd92` (for some reason my Mac does this). Note that this new pattern won't match strings without `VID:PID=`, but I think pyserial always provides that.

I also fixed an error I was getting because pyserial 3 expects strings to be encoded into bytes before writing them. With both of those fixes it's working well under python 2 and 3 on my Mac.

Lastly, I put a try/finally in `util.draw` so that it always turns the motors off and lifts the pen, even if interrupted with ctrl+c. Multiple calls to `pen_up` don't seem to do anything bad, so I figured it was a safe change.