### PR TITLE
Reset _path on pendown

### DIFF
--- a/axi/turtle.py
+++ b/axi/turtle.py
@@ -34,6 +34,7 @@ class Turtle(object):
 
     def pd(self):
         self.pen = True
+        self._path = [(self.x, self.y)]
     pendown = down = pd
 
     def pu(self):


### PR DESCRIPTION
We should reset the path in case the pen moved in the penup location so we don't have a line from the last penup location to the current pendown location when we put our pen down.